### PR TITLE
Context menu

### DIFF
--- a/client/bsg/ui/ContextMenu.js
+++ b/client/bsg/ui/ContextMenu.js
@@ -32,7 +32,8 @@ ContextMenu.prototype = {
 			console.log("No structure info found with structureId " + structure.name);
 		var structureTypeInfo = this.data.structureTypes[structureInfo.structureType];
 
-		var html = "<h2>" + structure.name + "</h2>" +
+		var html = "<h2>" + structureInfo.name + "</h2>" +
+			"<div class='structureicon " + structureInfo.iconCss + "'></div>" +
 			"<span id='citizencounter'>" + citizenFormatter() + "</span>" +
 			"<div id='structureslider'></div>";
 

--- a/client/css/contextmenu.css
+++ b/client/css/contextmenu.css
@@ -25,6 +25,17 @@
 
 }
 
+.contextmenu h2 {
+	text-align: center;
+}
+
+.contextmenu .structureicon {
+	width: 150px;
+	height: 100px;
+	background-size: 100% 100%;
+	margin: auto;
+}
+
 .contextmenu #structureslider {
 	margin: 10px;
 }


### PR DESCRIPTION
Okay here are the basics for a context menu that appears when you click on a building. Right now it features a slider that you can drag to allocate citizens. The capacity of citizens that a building can have is configurable. At some point I will implement a restriction on the allocation that checks if you actually have enough citizens. Also, I changed that right after placing a building you're out of placement mode. This way you can actually assign citizens straight away. We'll have to playtest to know how this works, maybe it's disturbing the workflow of placing a whole bunch of buildings.. dunno

(I hope I didn't screw anything up. I made a previous pull request on master but forgot to push some stuff. I deleted that branch and made a new one. But this one is showing only the latest commit ... I'll keep my local branch safe for now. Would be nice if someone could fetch, check and merge)
